### PR TITLE
Add squash MSVC support

### DIFF
--- a/pithy.c
+++ b/pithy.c
@@ -358,8 +358,12 @@ size_t pithy_Compress(const char *uncompressed, size_t uncompressedLength, char 
   
   size_t hashTableSize = 0x100ul, maxHashTableSize = 1 << (12ul + (((compressionLevel < 0) ? 0 : (compressionLevel > 9) ? 9 : compressionLevel) / 2ul));
   while((hashTableSize < maxHashTableSize) && (hashTableSize < uncompressedLength)) { hashTableSize <<= 1; }
-  pithy_hashOffset_t stackHashTable[hashTableSize], *heapHashTable = NULL, *hashTable = stackHashTable;
-  if((sizeof(pithy_hashOffset_t) * hashTableSize) >= (1024ul * 128ul)) { if((heapHashTable = malloc(sizeof(pithy_hashOffset_t) * hashTableSize)) == NULL) { return(0ul); } hashTable = heapHashTable; }
+  pithy_hashOffset_t *heapHashTable = NULL, *hashTable = NULL;
+#ifndef _MSC_VER
+  pithy_hashOffset_t stackHashTable[hashTableSize];
+  hashTable = stackHashTable;
+#endif
+  if(hashTable == NULL || (sizeof(pithy_hashOffset_t) * hashTableSize) >= (1024ul * 128ul)) { if((heapHashTable = malloc(sizeof(pithy_hashOffset_t) * hashTableSize)) == NULL) { return(0ul); } hashTable = heapHashTable; }
   size_t x = 0ul;
   for(x = 0ul; x < hashTableSize; x++) { hashTable[x] = uncompressed; }
   

--- a/pithy.c
+++ b/pithy.c
@@ -81,7 +81,11 @@ enum {
 #define PITHY_PREFETCH(ptr)
 #endif // defined (__GNUC__) && (__GNUC__ >= 3) 
 
+#ifdef _MSC_VER
+#define PITHY_STATIC_INLINE    static __forceinline
+#else
 #define PITHY_STATIC_INLINE    static __inline__ PITHY_ATTRIBUTES(always_inline)
+#endif
 #define PITHY_ALIGNED(x)                         PITHY_ATTRIBUTES(aligned(x))
 
 #if defined(NS_BLOCK_ASSERTIONS) && !defined(NDEBUG)

--- a/pithy.c
+++ b/pithy.c
@@ -91,7 +91,11 @@ enum {
 #ifdef NDEBUG
 #define DCHECK(condition) 
 #else
+#ifdef _MSC_VER
+#define DCHECK(condition) do { if(PITHY_EXPECT_F(!(condition))) { fprintf(stderr, "%s / %s @ %ld: Invalid parameter not satisfying: %s", __FILE__, __FUNCSIG__, (long)__LINE__, #condition); fflush(stderr); abort(); } } while(0)
+#else
 #define DCHECK(condition) do { if(PITHY_EXPECT_F(!(condition))) { fprintf(stderr, "%s / %s @ %ld: Invalid parameter not satisfying: %s", __FILE__, __PRETTY_FUNCTION__, (long)__LINE__, #condition); fflush(stderr); abort(); } } while(0)
+#endif
 #endif
 
 

--- a/pithy.c
+++ b/pithy.c
@@ -228,8 +228,9 @@ PITHY_STATIC_INLINE int pithy_Log2Floor(uint32_t n) {
 }
 
 PITHY_STATIC_INLINE int pithy_FindLSBSetNonZero32(uint32_t n) {
-  int i = 0, rc = 31;
-  for(i = 4, shift = 1 << 4; i >= 0; --i) { const uint32_t x = n << shift; if(x != 0u) { n = x; rc -= shift; } shift >>= 1; }
+  int i;
+  uint32_t rc = 31, shift = 1 << 4;
+  for(i = 4; i >= 0; --i) { const uint32_t x = n << shift; if(x != 0u) { n = x; rc -= shift; } shift >>= 1; }
   return(rc);
 }
 

--- a/pithy.c
+++ b/pithy.c
@@ -300,7 +300,7 @@ PITHY_STATIC_INLINE size_t pithy_FindMatchLength(const char *s1, const char *s2,
 
 
 PITHY_STATIC_INLINE char *pithy_EmitLiteral(char *op, const char *literal, size_t len, int allow_fast_path) {
-  ssize_t n = len - 1l;
+  ptrdiff_t n = len - 1l;
   if(PITHY_EXPECT_T(n < 60l)) { *op++ = PITHY_LITERAL | (n << 2); if(PITHY_EXPECT_T(allow_fast_path) && PITHY_EXPECT_T(len <= 16ul)) { pithy_Move128(op, literal); return(op + len); } }
   else { char *base = op; int count = 0; op++; while(n > 0l) { *op++ = n & 0xff; n >>= 8; count++; } DCHECK((count >= 1) && (count <= 4)); *base = PITHY_LITERAL | ((59 + count) << 2); }
   memcpy(op, literal, len);
@@ -318,7 +318,7 @@ PITHY_STATIC_INLINE char *pithy_EmitCopyGreaterThan63(char *op, size_t offset, s
 
 PITHY_STATIC_INLINE char *pithy_EmitCopyLessThan63(char *op, size_t offset, size_t len) {
   DCHECK((len < 63ul) && (len >= 4ul) && (offset < kBlockSize));
-  if(PITHY_EXPECT_T(len < 12ul) && PITHY_EXPECT_T(offset < 2048ul)) { ssize_t lenMinus4 = len - 4l; DCHECK(lenMinus4 < 8l); *op++ = PITHY_COPY_1_BYTE_OFFSET | (lenMinus4 << 2) | ((offset >> 8) << 5); *op++ = offset & 0xff; }
+  if(PITHY_EXPECT_T(len < 12ul) && PITHY_EXPECT_T(offset < 2048ul)) { ptrdiff_t lenMinus4 = len - 4l; DCHECK(lenMinus4 < 8l); *op++ = PITHY_COPY_1_BYTE_OFFSET | (lenMinus4 << 2) | ((offset >> 8) << 5); *op++ = offset & 0xff; }
   else { if(PITHY_EXPECT_T(offset < 65536ul)) { *op++ = PITHY_COPY_2_BYTE_OFFSET | ((len - 1ul) << 2); pithy_StoreHost16(op, offset); op += 2ul; }
          else                                 { *op++ = PITHY_COPY_3_BYTE_OFFSET | ((len - 1ul) << 2); pithy_StoreHost24(op, offset); op += 3ul; } }
   return(op);
@@ -391,7 +391,7 @@ size_t pithy_Compress(const char *uncompressed, size_t uncompressedLength, char 
           matchCandidatePtr                = hashTable[uncompressedBytesHash];
           DCHECK((matchCandidatePtr >= uncompressed) && (matchCandidatePtr < uncompressedPtr));
           hashTable[uncompressedBytesHash] = uncompressedPtr;
-        } while((PITHY_EXPECT_T(uncompressedBytes != pithy_Load32(matchCandidatePtr))) || PITHY_EXPECT_F((uncompressedPtr - matchCandidatePtr) >= ((ssize_t)(kBlockSize - 2ul))));
+        } while((PITHY_EXPECT_T(uncompressedBytes != pithy_Load32(matchCandidatePtr))) || PITHY_EXPECT_F((uncompressedPtr - matchCandidatePtr) >= ((ptrdiff_t)(kBlockSize - 2ul))));
         
         DCHECK((nextEmitUncompressedPtr + 16ul) <= uncompressedEnd);
         compressedPtr = pithy_EmitLiteral(compressedPtr, nextEmitUncompressedPtr, uncompressedPtr - nextEmitUncompressedPtr, 1);
@@ -432,7 +432,7 @@ size_t pithy_Compress(const char *uncompressed, size_t uncompressedLength, char 
           matchCandidatePtr                = hashTable[uncompressedBytesHash];
           DCHECK((matchCandidatePtr >= uncompressed) && (matchCandidatePtr < uncompressedPtr));
           hashTable[uncompressedBytesHash] = uncompressedPtr;
-        } while(PITHY_EXPECT_F(uncompressedBytes == pithy_Load32(matchCandidatePtr)) && PITHY_EXPECT_T((uncompressedPtr - matchCandidatePtr) < ((ssize_t)(kBlockSize - 2ul))));
+        } while(PITHY_EXPECT_F(uncompressedBytes == pithy_Load32(matchCandidatePtr)) && PITHY_EXPECT_T((uncompressedPtr - matchCandidatePtr) < ((ptrdiff_t)(kBlockSize - 2ul))));
         
         nextUncompressedBytes     = pithy_GetUint32AtOffset(uncompressedBytes64, 4u);
         nextUncompressedBytesHash = pithy_HashBytes(nextUncompressedBytes, shift);
@@ -518,7 +518,7 @@ int pithy_Decompress(const char *compressed, size_t compressedLength, char *deco
     
     const unsigned char c          = *((const unsigned char *)(compressedPtr++));
     const unsigned char cLowerBits = (c & 0x3u);
-    const ssize_t       spaceLeft  = (decompressedEnd - decompressedPtr);
+    const ptrdiff_t     spaceLeft  = (decompressedEnd - decompressedPtr);
     
     if((cLowerBits == PITHY_LITERAL)) {
       size_t literalLength = (c >> 2) + 1;
@@ -530,7 +530,7 @@ int pithy_Decompress(const char *compressed, size_t compressedLength, char *deco
           literalLength = (pithy_LoadHost32(compressedPtr) & pithy_wordmask[literalLengthBytes]) + 1;
           compressedPtr += literalLengthBytes;
         }
-        if(PITHY_EXPECT_F(spaceLeft < (ssize_t)literalLength) || PITHY_EXPECT_F((compressedPtr + literalLength) > compressedEnd)) { break; }
+        if(PITHY_EXPECT_F(spaceLeft < (ptrdiff_t)literalLength) || PITHY_EXPECT_F((compressedPtr + literalLength) > compressedEnd)) { break; }
         memcpy(decompressedPtr, compressedPtr, literalLength);
       }
       nextCompressedPtr  = compressedPtr + literalLength;
@@ -545,14 +545,14 @@ int pithy_Decompress(const char *compressed, size_t compressedLength, char *deco
       
       DCHECK((compressedPtr <= compressedEnd) && (copyOffset > 0ul) && (spaceLeft > 0l) && (length > 0ul));
       
-      if(PITHY_EXPECT_F((decompressedPtr - decompressedOut) <= ((ssize_t)copyOffset - 1l))) { break; }
+      if(PITHY_EXPECT_F((decompressedPtr - decompressedOut) <= ((ptrdiff_t)copyOffset - 1l))) { break; }
       if(PITHY_EXPECT_T(length <= 16ul) && PITHY_EXPECT_T(copyOffset >= 16ul) && PITHY_EXPECT_T(spaceLeft >= 16l)) { pithy_Move128(decompressedPtr, decompressedPtr - copyOffset); }
       else {
         if(PITHY_EXPECT_F(length >= 63ul)) { if(PITHY_EXPECT_T(length == 63ul)) { if(PITHY_EXPECT_F((compressedPtr + 1) > compressedEnd)) { break; } length = (*((unsigned char *)compressedPtr++)) + 63ul;          }
                                              else                               { if(PITHY_EXPECT_F((compressedPtr + 2) > compressedEnd)) { break; } length = pithy_LoadHost16(compressedPtr); compressedPtr += 2ul; } }
         
-        char    *copyFrom   = decompressedPtr - copyOffset, *copyTo = decompressedPtr;
-        ssize_t  copyLength = (ssize_t)length;
+        char     *copyFrom   = decompressedPtr - copyOffset, *copyTo = decompressedPtr;
+        ptrdiff_t copyLength = (ptrdiff_t)length;
         
         if(PITHY_EXPECT_F(copyLength > 256l) && PITHY_EXPECT_T(copyOffset > (size_t)copyLength)) { if(PITHY_EXPECT_F(spaceLeft < copyLength)) { break; } memcpy(copyTo, copyFrom, copyLength); }
         else {


### PR DESCRIPTION
A few changes to allow pithy to compile with MSVC. See quixdb/squash#145.
